### PR TITLE
Fixed links not working correctly on command error

### DIFF
--- a/src/events/errors/commandError.js
+++ b/src/events/errors/commandError.js
@@ -16,7 +16,7 @@ module.exports = class extends Event {
     ) {
       message.channel
         .sendCustom(
-          `${message.client.emoji.fail} Hey pogger! An Error just occured, make sure to report it here ${config.discord}!`
+          `${message.client.emoji.fail} Hey pogger! An Error just occured, make sure to report it here! ${config.discord}`
         )
         .catch(() => {});
     }


### PR DESCRIPTION
Found an issue with discord invite links not working on the bot, decided to fix it by moving the ! to the end of the word 'here'